### PR TITLE
feat(arguments): defined arguments for start,stop and logout

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,4 @@
+set -e
+
+cargo build --release
+cp target/release/jired ~/.local/bin/jired

--- a/src/boards/clickup.rs
+++ b/src/boards/clickup.rs
@@ -1,18 +1,2 @@
-//use super::Board;
-//use async_trait::async_trait;
-//
-//use crate::error::Result;
-//
-//struct ClickUp {}
-//#[async_trait]
-//impl Board for ClickUp {
-//    async fn new() -> Self {
-//        unimplemented!()
-//    }
-//    async fn init(self) -> Result<()> {
-//        unimplemented!()
-//    }
-//    async fn get_project_issues(&self, _project: &str) -> Result<()> {
-//        unimplemented!()
-//    }
-//}
+// will be implmented at the latter part of the project, jira and clockify are in the focus
+

--- a/src/boards/jira.rs
+++ b/src/boards/jira.rs
@@ -2,9 +2,9 @@ use async_trait::async_trait;
 use reqwest::{Client, ClientBuilder};
 use strum::{EnumIter, IntoEnumIterator};
 
-use crate::Args;
 use crate::common::{Secrets, helpers};
 use crate::error::{Error, Result};
+use crate::{Args, Commands};
 
 use super::Board;
 
@@ -74,9 +74,25 @@ impl Board for Jira {
     }
 
     async fn process_arguments(&self, args: Args) -> Result<()> {
-        if args.logout.unwrap_or(false) {
-            self.logout().await?;
+        match args.command {
+            Commands::Start {
+                project_name,
+                pattern,
+                till,
+            } => {
+                println!("{:?} {:?} {:?}", project_name, pattern, till)
+            }
+            Commands::Logout {} => {
+                println!("logout");
+            }
+            Commands::Stop { at } => {
+                println!("stoping  at {:?}", at);
+            }
         }
+
+        //if args.command.unwrap_or(false) {
+        self.logout().await?;
+        //}
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,14 +5,61 @@ pub mod common;
 pub mod error;
 pub mod prelude;
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
-/// Arguments for the cli
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 pub struct Args {
-    /// Logout, removes user credential from local machine
-    /// user must login again to use the cli
-    #[arg(short, long)]
-    logout: Option<bool>,
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    /// Define when a task starts
+    Start {
+        /// Project short code (eg: ticket id's prefix)
+        #[arg(value_name = "projectcode")]
+        project_name: String,
+
+        /// Fuzzy text to search the right ticket, so you do not have remember the ticket id to log
+        /// time
+        #[arg(value_name = "pattern")]
+        pattern: String,
+
+        #[command(subcommand)]
+        till: Option<StartSubcommandA>,
+    },
+    /// Define when to stop the current task
+    Stop {
+        /// Can use this argument to stop the current task at some point of the day instead of the
+        /// current time
+        #[arg(value_name = "at")]
+        at: Option<String>,
+    },
+    /// Logout, removing the secrets
+    Logout,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum StartSubcommandA {
+    /// You can specify the time, will argument passed program will create the entry at once,
+    /// no  evaluations are done again
+    Till {
+        #[arg(value_name = "TILL")]
+        till: String,
+
+        #[command(subcommand)]
+        from: Option<StartSubcommandB>,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum StartSubcommandB {
+    /// Can use this argument to start the task at some point of the day instead of the current
+    /// system time
+    From {
+        #[arg(value_name = "FROM")]
+        start: String,
+    },
 }


### PR DESCRIPTION
Define the argument system for start, stop and logout, using derive

jj start <project-code> <pattern>

# Time stamp the end of a task
jj stop

# Task with start and end time
jj start <project-code> <pattern> till 1000 from 0900